### PR TITLE
Add "CLEAR OUT SOUL" instead of "CLEAR USER DATA" and adjust battery voltages in syscon for better battery life.

### DIFF
--- a/animProcess/src/cozmoAnim/faceDisplay/faceInfoScreenManager.cpp
+++ b/animProcess/src/cozmoAnim/faceDisplay/faceInfoScreenManager.cpp
@@ -302,7 +302,7 @@ void FaceInfoScreenManager::Init(Anim::AnimContext* context, Anim::AnimationStre
 #if ENABLE_SELF_TEST
   ADD_MENU_ITEM(Main, "SELF TEST", SelfTest);
 #endif
-  ADD_MENU_ITEM(Main, "CLEAR USER DATA", ClearUserData);
+  ADD_MENU_ITEM(Main, "CLEAR OUT SOUL", ClearUserData);
 
   // === Self test screen ===
   ADD_MENU_ITEM(SelfTest, "EXIT", Main);

--- a/animProcess/src/cozmoAnim/faceDisplay/faceInfoScreenManager.cpp
+++ b/animProcess/src/cozmoAnim/faceDisplay/faceInfoScreenManager.cpp
@@ -207,9 +207,9 @@ void FaceInfoScreenManager::Init(Anim::AnimContext* context, Anim::AnimationStre
   ADD_SCREEN(FAC, None);
   ADD_SCREEN(CustomText, None);
   ADD_SCREEN(Main, Network);
-  ADD_SCREEN_WITH_TEXT(ClearUserData, Main, {"CLEAR USER DATA?"});
-  ADD_SCREEN_WITH_TEXT(ClearUserDataFail, Main, {"CLEAR USER DATA FAILED"});
-  ADD_SCREEN_WITH_TEXT(Rebooting, Rebooting, {"REBOOTING..."});
+  ADD_SCREEN_WITH_TEXT(ClearUserData, Main, {"CLEAR OUT SOUL?"});
+  ADD_SCREEN_WITH_TEXT(ClearUserDataFail, Main, {"CLEARING OUT SOUL FAILED"});
+  ADD_SCREEN_WITH_TEXT(Rebooting, Rebooting, {"Vector will remember that..."});
   ADD_SCREEN_WITH_TEXT(SelfTest, Main, {"START SELF TEST?"});
   ADD_SCREEN(SelfTestRunning, SelfTestRunning)
   ADD_SCREEN(Network, SensorInfo);

--- a/robot/syscon/src/analog.cpp
+++ b/robot/syscon/src/analog.cpp
@@ -22,11 +22,11 @@ static const int SELECTED_CHANNELS = 0
 
 static const int      TICKS_PER_SECOND = 200;
 
-static const uint16_t BATTERY_FULL_VOLTAGE = ADC_VOLTS(4.075); // 4.2 in a perfect world, but give some room for ADC variance, imperfect battery, etc.
+static const uint16_t BATTERY_FULL_VOLTAGE = ADC_VOLTS(4.1); // 4.2 in a perfect world, but give some room for ADC variance, imperfect battery, etc.
 static const int      CHARGE_FULL_TIME = TICKS_PER_SECOND * 60 * 5;           // 5 minutes
 
 static const uint16_t TRANSITION_POINT = ADC_VOLTS(4.3);
-static const uint32_t FALLING_EDGE = ADC_WINDOW(ADC_VOLTS(3.50), ~0);
+static const uint32_t FALLING_EDGE = ADC_WINDOW(ADC_VOLTS(3.40), ~0); // Minimum voltage?
 static const int      MINIMUM_ON_CHARGER = 5;
 
 static const uint16_t*  TEMP30_CAL_ADDR = (uint16_t*)0x1FFFF7B8;

--- a/robot/syscon/src/analog.cpp
+++ b/robot/syscon/src/analog.cpp
@@ -338,8 +338,8 @@ static void handleTemperature() {
 
 static void handleLowBattery() {
   // Levels
-  static const uint32_t EMERGENCY_POWER_DOWN_POINT = ADC_VOLTS(3.4);
-  static const uint32_t LOW_VOLTAGE_POWER_DOWN_POINT = ADC_VOLTS(3.62);
+  static const uint32_t EMERGENCY_POWER_DOWN_POINT = ADC_VOLTS(3.3);
+  static const uint32_t LOW_VOLTAGE_POWER_DOWN_POINT = ADC_VOLTS(3.4);
   static const int      LOW_VOLTAGE_POWER_DOWN_TIME = 45*TICKS_PER_SECOND; // 45 seconds
   static const int      EARLY_POWER_COUNT_TIME = TICKS_PER_SECOND; // 1 second
 


### PR DESCRIPTION
Change the "CLEAR USER DATA" option to "CLEAR OUT SOUL" just like the older versions of wire-os did. Also change the battery voltages in syscon to work better with a newer and larger battery so Vector will hopefully have longer runtime.