### PR TITLE
Change charging and low battery lights

### DIFF
--- a/resources/config/engine/lights/backpackLights/badCharger.json
+++ b/resources/config/engine/lights/backpackLights/badCharger.json
@@ -5,5 +5,5 @@
   "offPeriod_ms"            : [198,198,198],
   "transitionOnPeriod_ms"   : [200,200,200],
   "transitionOffPeriod_ms"  : [200,200,200],
-  "offset"                  : [198,99,0]
+  "offset"                  : [0,99,198]
 }

--- a/resources/config/engine/lights/backpackLights/badCharger.json
+++ b/resources/config/engine/lights/backpackLights/badCharger.json
@@ -1,9 +1,9 @@
 {
   "onColors"                : [[1, 0, 0, 1], [1, 0, 0, 1], [1, 0, 0, 1]],
   "offColors"               : [[0, 0, 0, 1], [0, 0, 0, 1], [0, 0, 0, 1]],
-  "onPeriod_ms"             : [600,600,600],
-  "offPeriod_ms"            : [600,600,600],
-  "transitionOnPeriod_ms"   : [300,300,300],
-  "transitionOffPeriod_ms"  : [300,300,300],
-  "offset"                  : [0,600,0]
+  "onPeriod_ms"             : [99,99,99],
+  "offPeriod_ms"            : [198,198,198],
+  "transitionOnPeriod_ms"   : [200,200,200],
+  "transitionOffPeriod_ms"  : [200,200,200],
+  "offset"                  : [198,99,0]
 }

--- a/resources/config/engine/lights/backpackLights/charging.json
+++ b/resources/config/engine/lights/backpackLights/charging.json
@@ -1,9 +1,9 @@
 {
-  "onColors"                : [[0, 1, 0, 1], [0, 0, 1, 1], [1, 0, 0, 1]],
+  "onColors"                : [[0, 0, 1, 1], [0, 1, 0, 1], [1, 0, 0, 1]],
   "offColors"               : [[0, 0, 0, 1], [0, 0, 0, 1], [0, 0, 0, 1]],
-  "onPeriod_ms"             : [600,1200,1800],
-  "offPeriod_ms"            : [1200,600,0],
-  "transitionOnPeriod_ms"   : [300,300,300],
-  "transitionOffPeriod_ms"  : [300,300,300],
+  "onPeriod_ms"             : [1000,1000,1000],
+  "offPeriod_ms"            : [1000,1000,1000],
+  "transitionOnPeriod_ms"   : [600,600,600],
+  "transitionOffPeriod_ms"  : [800,800,800],
   "offset"                  : [1200,600,0]
 }


### PR DESCRIPTION
Cooler animations that better suit Vector. Charging now has the lights fade out one by one while low battery now crawls along the entire backpack.