### PR TITLE
Rename TransitionToHeadCalibration to TransitionToMotorCalibration

### DIFF
--- a/engine/aiComponent/behaviorComponent/behaviors/reactions/behaviorReactToCliff.cpp
+++ b/engine/aiComponent/behaviorComponent/behaviors/reactions/behaviorReactToCliff.cpp
@@ -435,21 +435,21 @@ void BehaviorReactToCliff::TransitionToRecoveryBackup()
                  cliffComponent.GetCliffDetectedFlags());
         TransitionToStuckOnEdge();
       } else if (_dVars.persistent.putDownOnCliff) {
-        TransitionToHeadCalibration();
+        TransitionToMotorCalibration();
       } else {
         TransitionToVisualExtendCliffs();
       }
     };
     DelegateIfInControl(backupAction, callback);
   } else if (_dVars.persistent.putDownOnCliff) {
-    TransitionToHeadCalibration();
+    TransitionToMotorCalibration();
   } else {
     TransitionToVisualExtendCliffs();
   }
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-void BehaviorReactToCliff::TransitionToHeadCalibration()
+void BehaviorReactToCliff::TransitionToMotorCalibration()
 {
   DEBUG_SET_STATE(CalibratingHead);
   // The `putDownOnCliff` flag is what triggers the calling of this method.

--- a/engine/aiComponent/behaviorComponent/behaviors/reactions/behaviorReactToCliff.h
+++ b/engine/aiComponent/behaviorComponent/behaviors/reactions/behaviorReactToCliff.h
@@ -53,7 +53,7 @@ private:
   void TransitionToStuckOnEdge();
   void TransitionToPlayingCliffReaction();
   void TransitionToRecoveryBackup();
-  void TransitionToHeadCalibration();
+  void TransitionToMotorCalibration();
   void TransitionToVisualExtendCliffs();
   void TransitionToFaceAndBackAwayCliff();
   

--- a/engine/aiComponent/behaviorComponent/behaviors/reactions/behaviorReactToPutDown.cpp
+++ b/engine/aiComponent/behaviorComponent/behaviors/reactions/behaviorReactToPutDown.cpp
@@ -83,10 +83,10 @@ void BehaviorReactToPutDown::TransitionToPlayingPutDownAnimation()
     
   // Get the appropriate action/animation to play
   auto action = new TriggerLiftSafeAnimationAction(AnimationTrigger::ReactToPutDown);
-  DelegateIfInControl(action, &BehaviorReactToPutDown::TransitionToHeadCalibration);
+  DelegateIfInControl(action, &BehaviorReactToPutDown::TransitionToMotorCalibration);
 }
   
-void BehaviorReactToPutDown::TransitionToHeadCalibration()
+void BehaviorReactToPutDown::TransitionToMotorCalibration()
 {
   DEBUG_SET_STATE(CalibratingHead);
 

--- a/engine/aiComponent/behaviorComponent/behaviors/reactions/behaviorReactToPutDown.h
+++ b/engine/aiComponent/behaviorComponent/behaviors/reactions/behaviorReactToPutDown.h
@@ -39,7 +39,7 @@ protected:
 
 private:
   void TransitionToPlayingPutDownAnimation();
-  void TransitionToHeadCalibration();
+  void TransitionToMotorCalibration();
   void TransitionToPlayingWaitAnimation();
 
   struct InstanceConfig {


### PR DESCRIPTION
Just a quick code change, has no affect on functionality of the robot and is just to make the code more clear.